### PR TITLE
feat: add type checking and intellisense configuration for C and C++

### DIFF
--- a/lua/core/plugin_config/lsp_config.lua
+++ b/lua/core/plugin_config/lsp_config.lua
@@ -34,6 +34,7 @@ require("lspconfig").ts_ls.setup({})
 require("lspconfig").gopls.setup({})
 require("lspconfig").tailwindcss.setup({})
 require('lspconfig').pyright.setup({})
+require('lspconfig').clangd.setup({})
 
 vim.api.nvim_create_autocmd('LspAttach', {
   group = vim.api.nvim_create_augroup('UserLspConfig', {}),

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -40,6 +40,7 @@ require("lazy").setup({
   opts = {
     ensure_installed = {
       "pyright",
+      "clangd",
     }
   },
 })


### PR DESCRIPTION
This pull request adds support for the Clang Language Server (`clangd`) in the Neovim configuration. The changes ensure that `clangd` is properly set up and included in the list of installed language servers.

### Language Server Configuration Updates:

* Added `clangd` setup to the LSP configuration in `lua/core/plugin_config/lsp_config.lua`. This ensures that the Clang Language Server is initialized when Neovim starts.

* Included `clangd` in the `ensure_installed` list in `lua/core/plugins.lua`. This guarantees that `clangd` is installed automatically when the configuration is loaded.